### PR TITLE
Corrigido parâmetro DATA e adicionado cancelamento da PreAutorização

### DIFF
--- a/src/Omnipay/Komerci/BaseRequest.php
+++ b/src/Omnipay/Komerci/BaseRequest.php
@@ -83,6 +83,21 @@ abstract class BaseRequest extends AbstractRequest
         return $this->setParameter('numautor', $value);
     }
 
+    public function getDate()
+    {
+        return $this->getParameter('date');
+    }
+
+    public function getFormattedDate()
+    {
+        return date('Ymd', strtotime($this->getParameter('date')));
+    }
+
+    public function setDate($value)
+    {
+        return $this->setParameter('date', $value);
+    }
+
     /**
      *
      * @param type $data

--- a/src/Omnipay/Komerci/BaseRequest.php
+++ b/src/Omnipay/Komerci/BaseRequest.php
@@ -90,7 +90,9 @@ abstract class BaseRequest extends AbstractRequest
 
     public function getFormattedDate()
     {
-        return date('Ymd', strtotime($this->getParameter('date')));
+        return $this->getParameter('date')
+            ? date('Ymd', strtotime(str_replace('/', '-', $this->getParameter('date'))))
+            : date('Ymd');
     }
 
     public function setDate($value)

--- a/src/Omnipay/Komerci/Message/WSConfPreAuthRequest.php
+++ b/src/Omnipay/Komerci/Message/WSConfPreAuthRequest.php
@@ -17,7 +17,7 @@ class WSConfPreAuthRequest extends WSAbstractRequest
             'Distribuidor' => '',
             'Total' => sprintf("%.2F", round($this->getAmount() * 100) / 100),
             'Parcelas' => $this->getFormattedInstallments(),
-            'Data' => date('Ymd'),
+            'Data' => $this->getFormattedDate(),
             'NumAutor' => $this->getNumAutor(),
             'NumCv' => $this->getTransactionReference(),
             'Concentrador' => '',


### PR DESCRIPTION
Bom dia amigo! 
Parabéns pelo trabalho, excelente código.

Precisei fazer alguns ajustes para que a confirmação e os cancelamentos funcionassem corretamente em produção:

- O parâmetro DATA estava fixo com o dia atual, mas precisa ser exatamente a data da transação.
- Adicionei a possibilidade de cancelar a PreAutorização, antes só cancelava depois de confirmada.

Abraço.